### PR TITLE
Use Post.onymouslyLikedBy instead of Post.lastOnymouslyLikedBy

### DIFF
--- a/src/store/ducks/posts/queries.js
+++ b/src/store/ducks/posts/queries.js
@@ -61,7 +61,7 @@ const postFragment = `
     likesDisabled
     onymousLikeCount
     anonymousLikeCount
-    lastOnymouslyLikedBy {
+    onymouslyLikedBy (limit: 1) {
       ...postUserFragment
     }
   }

--- a/src/store/ducks/users/queries.js
+++ b/src/store/ducks/users/queries.js
@@ -59,7 +59,7 @@ const userPostFragment = `
     likeStatus
     onymousLikeCount
     anonymousLikeCount
-    lastOnymouslyLikedBy {
+    onymouslyLikedBy (limit: 1) {
       ...userFragment
     }
   }

--- a/src/templates/ReactionsPreview/index.js
+++ b/src/templates/ReactionsPreview/index.js
@@ -22,36 +22,36 @@ const ReactionsPreviewTemplate = ({
   return (
     <View style={styling.root}>
       <View style={styling.likes}>
-        {path(['lastOnymouslyLikedBy', 'username'])(post) ?
+        {path(['onymouslyLikedBy', '0', 'username'])(post) ?
           <View style={styling.profile}>
             <Avatar
               size="micro"
-              thumbnailSource={{ uri: path(['lastOnymouslyLikedBy', 'photoUrl64p'])(post) }}
-              imageSource={{ uri: path(['lastOnymouslyLikedBy', 'photoUrl64p'])(post) }}
+              thumbnailSource={{ uri: path(['onymouslyLikedBy', '0', 'photoUrl64p'])(post) }}
+              imageSource={{ uri: path(['onymouslyLikedBy', '0', 'photoUrl64p'])(post) }}
             />
           </View>
         : null}
 
-        {path(['lastOnymouslyLikedBy', 'username'])(post) ?
+        {path(['onymouslyLikedBy', '0', 'username'])(post) ?
           <React.Fragment>
             {path(['anonymousLikeCount'])(post) + path(['onymousLikeCount'])(post) > 1 ?
               <Text style={styling.text}>
                 {t('Liked by {{username}} and many others', {
-                  username: path(['lastOnymouslyLikedBy', 'username'])(post),
+                  username: path(['onymouslyLikedBy', '0', 'username'])(post),
                   // count: path(['anonymousLikeCount'])(post) + path(['onymousLikeCount'])(post) - 1,
                 })}
               </Text>
             :
               <Text style={styling.text}>
                 {t('Liked by {{username}}', {
-                  username: path(['lastOnymouslyLikedBy', 'username'])(post),
+                  username: path(['onymouslyLikedBy', '0', 'username'])(post),
                 })}
               </Text>
             }
           </React.Fragment>
         : null}
 
-        {!path(['lastOnymouslyLikedBy', 'username'])(post) ?
+        {!path(['onymouslyLikedBy', '0', 'username'])(post) ?
           <React.Fragment>
             {path(['anonymousLikeCount'])(post) + path(['onymousLikeCount'])(post) >= 1 ?
               <Text style={styling.text}>


### PR DESCRIPTION
The new-ish field `Post.onymouslyLikedBy` does everything `Post.lastOnymouslyLikedBy` does and more: it's a list, so you can retrieve more than just the latest user that has liked the post. Users are order by when they liked the post, most recent first.

Once beta and production apps have been updated to use `Post.onymouslyLikedBy` instead of `Post.lastOnymouslyLikedBy`, I plan to remove `Post.lastOnymouslyLikedBy`.