### PR TITLE
Use Query.post instead of Query.getPost

### DIFF
--- a/src/store/ducks/posts/queries.js
+++ b/src/store/ducks/posts/queries.js
@@ -100,7 +100,7 @@ export const getPosts = `
 
 export const getPost = `
   query GetPost($postId: ID!) {
-    getPost(postId: $postId) {
+    post(postId: $postId) {
       ...postFragment
     }
   }
@@ -277,7 +277,7 @@ export const trendingPosts = `
 
 export const viewedBy = `
   query viewedBy($postId: ID!, $limit: Int, $nextToken: String) {
-    getPost(postId: $postId) {
+    post(postId: $postId) {
       viewedBy(limit: $limit, nextToken: $nextToken) {
         items {
           ...postUserFragment

--- a/src/store/ducks/posts/saga.js
+++ b/src/store/ducks/posts/saga.js
@@ -151,8 +151,8 @@ function* postsViewsGetRequest(req) {
 
   try {
     const data = yield AwsAPI.graphql(graphqlOperation(queries.viewedBy, req.payload))
-    const dataSelector = path(['data', 'getPost', 'viewedBy', 'items'])
-    const metaSelector = compose(omit(['items']), path(['data', 'getPost', 'viewedBy']))
+    const dataSelector = path(['data', 'post', 'viewedBy', 'items'])
+    const metaSelector = compose(omit(['items']), path(['data', 'post', 'viewedBy']))
 
     yield put(actions.postsViewsGetSuccess({ payload: req.payload, data: dataSelector(data), meta: metaSelector(data) }))
   } catch (error) {
@@ -300,7 +300,7 @@ function* postsSingleGetRequest(req) {
 
   try {
     const data = yield AwsAPI.graphql(graphqlOperation(queries.getPost, req.payload))
-    const selector = path(['data', 'getPost'])
+    const selector = path(['data', 'post'])
 
     yield put(actions.postsSingleGetSuccess({ data: selector(data), meta: data }))
   } catch (error) {


### PR DESCRIPTION
This is just a name change, the new `Query.post` should be behave the same as the old `Query.getPost`

The overall goal is that I would like the `Query` section of the api to look at lot more like what I see in [github's v4 graphql api](https://developer.github.com/v4/). Eventually all the `getX` fields in `Query` will either move or be renamed.

This PR is intended to be just minimal changes to move from `Query.getPost` to `Query.post`.