### PR TITLE
Scroll

### DIFF
--- a/src/components/PostCreate/Form.js
+++ b/src/components/PostCreate/Form.js
@@ -111,8 +111,8 @@ const PostCreateForm = ({
           type: 'action',
           enabled: !values.commentsDisabled,
         }, {
-          label: t('Likes'),
-          caption: t('Followers can like posts'),
+          label: t('First Like'),
+          caption: t('See the first user to like your post'),
           onPress: () => setFieldValue('likesDisabled', !values.likesDisabled),
           type: 'action',
           enabled: !values.likesDisabled,

--- a/src/components/PostEdit/Form.js
+++ b/src/components/PostEdit/Form.js
@@ -142,8 +142,8 @@ const PostEditForm = ({
           type: 'action',
           enabled: !values.commentsDisabled,
         }, {
-          label: t('Likes'),
-          caption: t('Followers can like posts'),
+          label: t('First Like'),
+          caption: t('See the first user to like your post'),
           onPress: () => setFieldValue('likesDisabled', !values.likesDisabled),
           type: 'action',
           enabled: !values.likesDisabled,

--- a/src/components/PostMedia/index.js
+++ b/src/components/PostMedia/index.js
@@ -32,10 +32,7 @@ const PostMedia = ({
   postsOnymouslyLikeRequest,
   postsDislikeRequest,
   handleProfilePress,
-  layoutPostMediaItemSuccess,
-  layoutPostMediaScroll,
   postsSingleGet,
-  onScroll,
   viewMore,
   handleViewMorePosts,
   postsGetTrendingPosts,
@@ -45,9 +42,6 @@ const PostMedia = ({
   const { t } = useTranslation()
 
   const handleScrollChange = (event) => {
-    if (navigation.state.routeName === 'PostMedia') {
-      onScroll(event.nativeEvent.contentOffset)
-    }
   }
 
   /**
@@ -112,8 +106,6 @@ const PostMedia = ({
             postsOnymouslyLikeRequest={postsOnymouslyLikeRequest}
             postsDislikeRequest={postsDislikeRequest}
             handleProfilePress={handleProfilePress}
-            onMeasure={layoutPostMediaItemSuccess}
-            scrollPosition={layoutPostMediaScroll.data.y}
           />
         )}
       />

--- a/src/components/PostMedia/index.service.js
+++ b/src/components/PostMedia/index.service.js
@@ -16,7 +16,6 @@ const PostMediaService = ({ children, navigation, ...props }) => {
   const postsGetTrendingPosts = useSelector(state => state.posts.postsGetTrendingPosts)
   const postsGetCache = useSelector(state => state.posts.postsGetCache)
 
-  const [viewMore, setViewMore] = useState(true)
   const feedRef = useRef()
 
   const postsSingleGetRequest = ({ postId }) =>
@@ -41,7 +40,11 @@ const PostMediaService = ({ children, navigation, ...props }) => {
     }
   }, [postsDelete.status])
 
-  const handleViewMorePosts = () => {
+  const onViewableItemsChanged = ({ viewableItems }) => {
+    const postIds = viewableItems.map(viewable => path(['item', 'postId'])(viewable))
+      .filter(item => item)
+
+    dispatch(postsActions.postsReportPostViewsRequest({ postIds }))
   }
 
   return children({
@@ -50,10 +53,9 @@ const PostMediaService = ({ children, navigation, ...props }) => {
     postsSingleGetRequest,
     ...props,
     postsMediaFeedGet: postsServices.cachedPostsMediaFeedGet(postsGetCache, userId, postId),
-    viewMore,
-    handleViewMorePosts,
     feedRef,
     routeName: navigation.getParam('routeName'),
+    onViewableItemsChanged,
   })
 }
 

--- a/src/components/PostMedia/index.service.js
+++ b/src/components/PostMedia/index.service.js
@@ -6,7 +6,6 @@ import * as postsServices from 'store/ducks/posts/services'
 import * as layoutActions from 'store/ducks/layout/actions'
 import { withNavigation } from 'react-navigation'
 import path from 'ramda/src/path'
-import useDebounce from 'react-use/lib/useDebounce'
 
 const PostMediaService = ({ children, navigation, ...props }) => {
   const dispatch = useDispatch()
@@ -16,9 +15,6 @@ const PostMediaService = ({ children, navigation, ...props }) => {
   const postsDelete = useSelector(state => state.posts.postsDelete)
   const postsGetTrendingPosts = useSelector(state => state.posts.postsGetTrendingPosts)
   const postsGetCache = useSelector(state => state.posts.postsGetCache)
-
-  const layoutPostMediaItem = useSelector(state => state.layout.layoutPostMediaItem)
-  const layoutPostMediaScroll = useSelector(state => state.layout.layoutPostMediaScroll)
 
   const [viewMore, setViewMore] = useState(true)
   const feedRef = useRef()
@@ -30,17 +26,9 @@ const PostMediaService = ({ children, navigation, ...props }) => {
     dispatch(postsActions.postsSingleGetRequest({ postId }))
   }, [postId])
 
-  const layoutPostMediaScrollSuccess = (payload) =>
-    dispatch(layoutActions.layoutPostMediaScrollSuccess(payload))
-
-  const layoutPostMediaItemSuccess = (payload) =>
-    dispatch(layoutActions.layoutPostMediaItemSuccess(payload))
-
   useEffect(() => {
     InteractionManager.runAfterInteractions(() => {
       dispatch(postsActions.postsReportPostViewsRequest({ postIds: [postId] }))
-      dispatch(layoutActions.layoutPostMediaItemIdle())
-      dispatch(layoutActions.layoutPostMediaScrollIdle())
     })
   }, [])
 
@@ -53,26 +41,7 @@ const PostMediaService = ({ children, navigation, ...props }) => {
     }
   }, [postsDelete.status])
 
-  useDebounce(() => {
-    const range = Object.keys(layoutPostMediaItem.data)
-    const goal = layoutPostMediaScroll.data.y
-    
-    if (!range.length || !goal) { return }
-    
-    const closest = range.reduce((prev, curr) =>
-      (Math.abs(curr - goal) < Math.abs(prev - goal) ? curr : prev)
-    )
-    
-    const closestPostId = layoutPostMediaItem.data[closest].postId
-    dispatch(postsActions.postsReportPostViewsRequest({ postIds: [closestPostId] }))
-
-    setViewMore(postId === closestPostId)
-  }, 1000, [layoutPostMediaScroll.data.y])
-
   const handleViewMorePosts = () => {
-    const range = Object.keys(layoutPostMediaItem.data).sort((a, b) => a - b)
-    const offset = parseInt(range[1], 10) - parseInt(range[0], 10)
-    feedRef.current.scrollToOffset({ animated: true, offset })
   }
 
   return children({
@@ -81,9 +50,6 @@ const PostMediaService = ({ children, navigation, ...props }) => {
     postsSingleGetRequest,
     ...props,
     postsMediaFeedGet: postsServices.cachedPostsMediaFeedGet(postsGetCache, userId, postId),
-    onScroll: layoutPostMediaScrollSuccess,
-    layoutPostMediaItemSuccess,
-    layoutPostMediaScroll,
     viewMore,
     handleViewMorePosts,
     feedRef,

--- a/src/components/PostsList/Post.js
+++ b/src/components/PostsList/Post.js
@@ -2,6 +2,7 @@ import React, { useRef, useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import {
   StyleSheet,
+  TouchableOpacity,
   View,
 } from 'react-native'
 import path from 'ramda/src/path'
@@ -31,32 +32,17 @@ const PostComponent = ({
   postsDislikeRequest,
   handleProfilePress,
   postsRestoreArchivedRequest,
-  onMeasure,
-  scrollPosition,
   priorityIndex,
+  handleScrollPrev,
+  handleScrollNext,
 }) => {
   const styling = styles(theme)
   const { t } = useTranslation()
 
   const ref = useRef(null)
-  const [position, setPosition] = useState(false)
-
-  const handleLayoutChange = useCallback(() => {
-    if (!['Feed', 'PostMedia'].includes(navigation.state.routeName)) { return }
-    ref.current.measure((fx, fy, width, height, px, py) => {
-      onMeasure({ postId: post.postId, measure: { fx, fy, width, height, px, py } })
-      setPosition({ py, height })
-    })
-  }, [])
-
-  // const shouldLoadImage = (
-  //   !['Feed', 'PostMedia'].includes(navigation.state.routeName) ||
-  //   Layout.window.height * 2 > position.py ||
-  //   (scrollPosition + position.height + Layout.window.height * 2 > position.py)
-  // )
 
   return (
-    <View style={styling.root} onLayout={handleLayoutChange} ref={ref}>
+    <View style={styling.root} ref={ref}>
       <HeaderComponent
         authUser={authUser}
         post={post}
@@ -68,13 +54,17 @@ const PostComponent = ({
         handleProfilePress={handleProfilePress}
         postsRestoreArchivedRequest={postsRestoreArchivedRequest}
       />
+
       <ListItemComponent post={post}>
         <ImageComponent
           thumbnailSource={{ uri: path(['mediaObjects', '0', 'url64p'])(post) }}
           imageSource={{ uri: path(['mediaObjects', '0', 'url4k'])(post) }}
           priorityIndex={priorityIndex}
         />
+        <TouchableOpacity style={styling.prev} onPress={handleScrollPrev} />
+        <TouchableOpacity style={styling.next} onPress={handleScrollNext} />
       </ListItemComponent>
+
       <ActionComponent
         authUser={authUser}
         post={post}
@@ -96,6 +86,20 @@ const styles = theme => StyleSheet.create({
   root: {
     flex: 1,
     backgroundColor: theme.colors.backgroundPrimary,
+  },
+  prev: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: '50%',
+    bottom: 0,
+  },
+  next: {
+    position: 'absolute',
+    top: 0,
+    left: '50%',
+    right: 0,
+    bottom: 0,
   },
 })
 

--- a/src/components/Privacy/Form.js
+++ b/src/components/Privacy/Form.js
@@ -42,8 +42,8 @@ const Privacy = ({
         onPress: toggleFollowCountsHidden,
         enabled: user.followCountsHidden,
       }, {
-        label: t('Likes'),
-        caption: t('Followers can like posts'),
+        label: t('First Like'),
+        caption: t('See the first user to like your post'),
         onPress: toggleLikesDisabled,
         enabled: !user.likesDisabled,
       }, {


### PR DESCRIPTION
- Edit texts for likes; Explaining that only the first user can like the post;
- Tap scroll on post in post feed to skip on prev/next post; Removed layout actions and reducers to significantly improve speed and performance; Scrolling prev/next is implemented using scrollToIndex prop on FlatList; Post analytics reporting is implemented using onViewableItemsChanged props on FlatList;
- Removed view more button on post page; Enabled tap left/right part of post component to scroll to prev/next post;