### PR TITLE
Update graphql queries to use `User.something` instead of `Query.getSomething`

### DIFF
--- a/src/store/ducks/posts/queries.js
+++ b/src/store/ducks/posts/queries.js
@@ -40,11 +40,13 @@ export const getFeed = `
 
 export const getStories = `
   query GetStories($userId: ID, $limit: Int, $nextToken: String = null) {
-    getStories(userId: $userId, limit: $limit, nextToken: $nextToken) {
-      items {
-        ...postFragment
+    user(userId: $userId) {
+      stories(limit: $limit, nextToken: $nextToken) {
+        items {
+          ...postFragment
+        }
+        nextToken
       }
-      nextToken
     }
   }
   ${postFragment}

--- a/src/store/ducks/posts/queries.js
+++ b/src/store/ducks/posts/queries.js
@@ -28,11 +28,13 @@ export const getPost = `
 
 export const getFeed = `
   query GetFeed($limit: Int = 20, $nextToken: String = null) {
-    getFeed(limit: $limit, nextToken: $nextToken) {
-      items {
-        ...postFragment
+    self {
+      feed(limit: $limit, nextToken: $nextToken) {
+        items {
+          ...postFragment
+        }
+        nextToken
       }
-      nextToken
     }
   }
   ${postFragment}

--- a/src/store/ducks/posts/queries.js
+++ b/src/store/ducks/posts/queries.js
@@ -5,11 +5,13 @@ import {
 
 export const getPosts = `
   query GetPosts($userId: ID, $postStatus: PostStatus, $nextToken: String = null) {
-    getPosts(userId: $userId, postStatus: $postStatus, nextToken: $nextToken) {
-      items {
-        ...postFragment
+    user(userId: $userId) {
+      posts(postStatus: $postStatus, nextToken: $nextToken) {
+        items {
+          ...postFragment
+        }
+        nextToken
       }
-      nextToken
     }
   }
   ${postFragment}

--- a/src/store/ducks/posts/saga.js
+++ b/src/store/ducks/posts/saga.js
@@ -225,8 +225,8 @@ function* postsFeedGetRequest(req) {
 
   try {
     const data = yield AwsAPI.graphql(graphqlOperation(queries.getFeed, req.payload))
-    const dataSelector = path(['data', 'getFeed', 'items'])
-    const metaSelector = compose(omit(['items']), path(['data', 'getFeed']))
+    const dataSelector = path(['data', 'self', 'feed', 'items'])
+    const metaSelector = compose(omit(['items']), path(['data', 'self', 'feed']))
 
     yield put(actions.postsFeedGetSuccess({ data: dataSelector(data), payload: req.payload, meta: metaSelector(data) }))
   } catch (error) {
@@ -239,8 +239,8 @@ function* postsFeedGetMoreRequest(req) {
 
   try {
     const data = yield AwsAPI.graphql(graphqlOperation(queries.getFeed, req.payload))
-    const dataSelector = path(['data', 'getFeed', 'items'])
-    const metaSelector = compose(omit(['items']), path(['data', 'getFeed']))
+    const dataSelector = path(['data', 'self', 'feed', 'items'])
+    const metaSelector = compose(omit(['items']), path(['data', 'self', 'feed']))
 
     yield put(actions.postsFeedGetMoreSuccess({ data: dataSelector(data), payload: req.payload, meta: metaSelector(data) }))
   } catch (error) {

--- a/src/store/ducks/posts/saga.js
+++ b/src/store/ducks/posts/saga.js
@@ -180,8 +180,8 @@ function* postsGetRequest(req) {
 
   try {
     const data = yield AwsAPI.graphql(graphqlOperation(queries.getPosts, { ...req.payload, postStatus: 'COMPLETED' }))
-    const dataSelector = path(['data', 'getPosts', 'items'])
-    const metaSelector = compose(omit(['items']), path(['data', 'getPosts']))
+    const dataSelector = path(['data', 'user', 'posts', 'items'])
+    const metaSelector = compose(omit(['items']), path(['data', 'user', 'posts']))
 
     yield put(actions.postsGetSuccess({ payload: req.payload, data: dataSelector(data), meta: metaSelector(data) }))
   } catch (error) {
@@ -194,8 +194,8 @@ function* postsGetMoreRequest(req) {
 
   try {
     const data = yield AwsAPI.graphql(graphqlOperation(queries.getPosts, { ...req.payload, postStatus: 'COMPLETED' }))
-    const dataSelector = path(['data', 'getPosts', 'items'])
-    const metaSelector = compose(omit(['items']), path(['data', 'getPosts']))
+    const dataSelector = path(['data', 'user', 'posts', 'items'])
+    const metaSelector = compose(omit(['items']), path(['data', 'user', 'posts']))
 
     yield put(actions.postsGetMoreSuccess({ payload: req.payload, data: dataSelector(data), meta: metaSelector(data) }))
   } catch (error) {
@@ -256,7 +256,7 @@ function* postsGetArchivedRequest(req) {
 
   try {
     const data = yield AwsAPI.graphql(graphqlOperation(queries.getPosts, { ...req.payload, postStatus: 'ARCHIVED' }))
-    const selector = path(['data', 'getPosts', 'items'])
+    const selector = path(['data', 'user', 'posts', 'items'])
 
     yield put(actions.postsGetArchivedSuccess({ data: selector(data), meta: data }))
   } catch (error) {

--- a/src/store/ducks/posts/saga.js
+++ b/src/store/ducks/posts/saga.js
@@ -25,7 +25,7 @@ function* postsStoriesGetRequest(req) {
 
   try {
     const data = yield AwsAPI.graphql(graphqlOperation(queries.getStories, req.payload))
-    const selector = path(['data', 'getStories', 'items'])
+    const selector = path(['data', 'user', 'stories', 'items'])
 
     yield put(actions.postsStoriesGetSuccess({ data: selector(data), meta: data }))
   } catch (error) {

--- a/src/store/ducks/users/queries.js
+++ b/src/store/ducks/users/queries.js
@@ -190,11 +190,13 @@ export const getMediaObjects = `
 
 export const getFollowedUsersWithStories = `
   query GetFollowedUsersWithStories($limit: Int, $nextToken: String) {
-    getFollowedUsersWithStories(limit: $limit, nextToken: $nextToken) {
-      items {
-        ...userFragment
+    self {
+      followedUsersWithStories(limit: $limit, nextToken: $nextToken) {
+        items {
+          ...userFragment
+        }
+        nextToken
       }
-      nextToken
     }
   }
   ${userFragment}

--- a/src/store/ducks/users/queries.js
+++ b/src/store/ducks/users/queries.js
@@ -176,11 +176,13 @@ export const setUserDetails = `
 
 export const getMediaObjects = `
   query GetMediaObjects($userId: ID) {
-    getMediaObjects(userId: $userId) {
-      items {
-        ...mediaObjectFragment
+    user(userId: $userId) {
+      mediaObjects {
+        items {
+          ...mediaObjectFragment
+        }
+        nextToken
       }
-      nextToken
     }
   }
   ${mediaObjectFragment}

--- a/src/store/ducks/users/queries.js
+++ b/src/store/ducks/users/queries.js
@@ -248,11 +248,13 @@ export const denyFollowerUser = `
 
 export const getStories = `
   query GetStories {
-    getStories {
-      items {
-        ...userPostFragment
+    self {
+      stories {
+        items {
+          ...userPostFragment
+        }
+        nextToken
       }
-      nextToken
     }
   }
   ${userPostFragment}

--- a/src/store/ducks/users/saga.js
+++ b/src/store/ducks/users/saga.js
@@ -93,7 +93,7 @@ function* usersGetFollowedUsersWithStoriesRequest(req) {
 
   try {
     const data = yield AwsAPI.graphql(graphqlOperation(queries.getFollowedUsersWithStories, req.payload))
-    const selector = path(['data', 'getFollowedUsersWithStories', 'items'])
+    const selector = path(['data', 'self', 'followedUsersWithStories', 'items'])
 
     yield put(actions.usersGetFollowedUsersWithStoriesSuccess({ data: selector(data), meta: data }))
   } catch (error) {

--- a/src/store/ducks/users/saga.js
+++ b/src/store/ducks/users/saga.js
@@ -29,7 +29,7 @@ function* usersStoriesGetRequest(req) {
 
   try {
     const data = yield AwsAPI.graphql(graphqlOperation(queries.getStories, req.payload))
-    const selector = path(['data', 'getStories', 'items'])
+    const selector = path(['data', 'self', 'stories', 'items'])
 
     yield put(actions.usersStoriesGetSuccess({ data: selector(data), meta: data }))
   } catch (error) {

--- a/src/store/ducks/users/saga.js
+++ b/src/store/ducks/users/saga.js
@@ -249,7 +249,7 @@ function* usersMediaObjectsGetRequest(req) {
 
   try {
     const data = yield AwsAPI.graphql(graphqlOperation(queries.getMediaObjects, req.payload))
-    const selector = path(['data', 'getMediaObjects', 'items'])
+    const selector = path(['data', 'user', 'mediaObjects', 'items'])
 
     yield put(actions.usersMediaObjectsGetSuccess({ data: selector(data), meta: data }))
   } catch (error) {


### PR DESCRIPTION
Each commit in this PR contains changes to go from using a top-level field (ie `Query.getSomething`) to using a user-level field (ie `User.something`).

These new fields should allow the frontend to request more data it might need all at once. For example, when displaying stories it should work to do a query that looks like:

```gql
self {
  followedUsersWithStories {
    items {
      userId
      username
      stories {
        items {
          postId
          ...
        }
      }
    }
  }
}
```

Previously I think this previously took two (or more?) separate queries. Note: that isn't part of this PR, but it should now be possible.

Once the frontend is no longer using the old `Query.getSomething` fields in both beta and production, then I will drop those `Query.getSomething` fields.

(As usual, I didn't test these changes so apologies in advance if there are some bugs in them)

Let me know if you have questions, thank you!