### PR TITLE
Use new Album.art, User.photo

### DIFF
--- a/src/components/Album/Albums.js
+++ b/src/components/Album/Albums.js
@@ -38,7 +38,7 @@ const AlbumLarge = ({
     const albumPosts = pathOr([], ['posts', 'items'])(album)
 
     if (!albumPosts.length) {
-      return [pathOr('', ['url480p'])(album)]
+      return [pathOr('', ['art', 'url480p'])(album)]
     }
 
     return albumPosts.map(post => post.image.url480p)

--- a/src/components/Album/index.js
+++ b/src/components/Album/index.js
@@ -30,8 +30,8 @@ const Album = ({
       <ScrollView bounces={false}>
         <View style={styling.content}>
           <ModalProfileComponent
-            thumbnailSource={{ uri: path(['ownedBy', 'photoUrl64p'])(album) }}
-            imageSource={{ uri: path(['ownedBy', 'photoUrl480p'])(album) }}
+            thumbnailSource={{ uri: path(['ownedBy', 'photo', 'url64p'])(album) }}
+            imageSource={{ uri: path(['ownedBy', 'photo', 'url480p'])(album) }}
             title={path(['ownedBy', 'username'])(album)}
             subtitle={path(['ownedBy', 'fullName'])(album)}
           />

--- a/src/components/Albums/Albums.js
+++ b/src/components/Albums/Albums.js
@@ -40,7 +40,7 @@ const AlbumLarge = ({
     const albumPosts = pathOr([], ['posts', 'items'])(album)
 
     if (!albumPosts.length) {
-      return [pathOr('', ['url480p'])(album)]
+      return [pathOr('', ['art', 'url480p'])(album)]
     }
 
     return albumPosts.map(post => post.image.url480p)

--- a/src/components/Comments/Comment.js
+++ b/src/components/Comments/Comment.js
@@ -27,8 +27,8 @@ const Comment = ({
     <View style={styling.root}>
       <TouchableOpacity style={styling.image} onPress={navigationActions.navigateProfile(navigation, { user: comment.commentedBy })}>
         <Avatar
-          thumbnailSource={{ uri: path(['commentedBy', 'photoUrl64p'])(comment) }}
-          imageSource={{ uri: path(['commentedBy', 'photoUrl64p'])(comment) }}
+          thumbnailSource={{ uri: path(['commentedBy', 'photo', 'url64p'])(comment) }}
+          imageSource={{ uri: path(['commentedBy', 'photo', 'url64p'])(comment) }}
         />
       </TouchableOpacity>
       <View style={styling.comment}>

--- a/src/components/PostCreate/Albums.js
+++ b/src/components/PostCreate/Albums.js
@@ -27,8 +27,8 @@ const Albums = ({
         {items.map((album, key) => (
           <TouchableOpacity style={[styling.album, styling.spacingRight]} key={key} onPress={() => setAlbumId(album.albumId)}>
             <ImageComponent
-              thumbnailSource={{ uri: path(['url64p'])(album) }}
-              imageSource={{ uri: path(['url480p'])(album) }}
+              thumbnailSource={{ uri: path(['art', 'url64p'])(album) }}
+              imageSource={{ uri: path(['art', 'url480p'])(album) }}
               priorityIndex={key}
             />
           </TouchableOpacity>

--- a/src/components/PostShare/index.js
+++ b/src/components/PostShare/index.js
@@ -82,8 +82,8 @@ const PostShare = ({
 
         <View style={styling.content}>
           <ModalProfileComponent
-            thumbnailSource={{ uri: path(['data', 'postedBy', 'photoUrl64p'])(postsSingleGet) }}
-            imageSource={{ uri: path(['data', 'postedBy', 'photoUrl480p'])(postsSingleGet) }}
+            thumbnailSource={{ uri: path(['data', 'postedBy', 'photo', 'url64p'])(postsSingleGet) }}
+            imageSource={{ uri: path(['data', 'postedBy', 'photo', 'url480p'])(postsSingleGet) }}
             title={path(['data', 'postedBy', 'username'])(postsSingleGet)}
             subtitle={`${t('Posted')} ${dayjs(path(['data', 'postedAt'])(postsSingleGet)).from(dayjs())}`}
           />

--- a/src/components/PostsList/Header.js
+++ b/src/components/PostsList/Header.js
@@ -50,8 +50,8 @@ const Header = ({
       <TouchableOpacity onPress={navigationActions.navigateProfile(navigation, { user: post.postedBy })}>
         <Avatar
           active
-          thumbnailSource={{ uri: path(['postedBy', 'photoUrl64p'])(post) }}
-          imageSource={{ uri: path(['postedBy', 'photoUrl64p'])(post) }}
+          thumbnailSource={{ uri: path(['postedBy', 'photo', 'url64p'])(post) }}
+          imageSource={{ uri: path(['postedBy', 'photo', 'url64p'])(post) }}
           themeCode={path(['postedBy', 'themeCode'])(post)}
         />
       </TouchableOpacity>

--- a/src/components/Profile/index.js
+++ b/src/components/Profile/index.js
@@ -157,8 +157,8 @@ const Profile = ({
             <Avatar
               size="large"
               active
-              thumbnailSource={{ uri: path(['data', 'photoUrl64p'])(usersGetProfile) }}
-              imageSource={{ uri: path(['data', 'photoUrl480p'])(usersGetProfile) }}
+              thumbnailSource={{ uri: path(['data', 'photo', 'url64p'])(usersGetProfile) }}
+              imageSource={{ uri: path(['data', 'photo', 'url480p'])(usersGetProfile) }}
               themeCode={path(['data', 'themeCode'])(usersGetProfile)}
             />
           </TouchableOpacity>

--- a/src/components/Search/Result.js
+++ b/src/components/Search/Result.js
@@ -52,8 +52,8 @@ const Result = ({
                 <TouchableOpacity onPress={navigationActions.navigateProfile(navigation, { user })}>
                   <Avatar
                     active
-                    thumbnailSource={{ uri: path(['photoUrl64p'])(user) }}
-                    imageSource={{ uri: path(['photoUrl64p'])(user) }}
+                    thumbnailSource={{ uri: path(['photo', 'url64p'])(user) }}
+                    imageSource={{ uri: path(['photo', 'url64p'])(user) }}
                     themeCode={path(['themeCode'])(user)}
                   />
                 </TouchableOpacity>

--- a/src/components/Settings/index.js
+++ b/src/components/Settings/index.js
@@ -43,8 +43,8 @@ const Settings = ({
       <TouchableOpacity onPress={() => navigation.navigate('ProfilePhoto')}>
         <Avatar
           size="large"
-          thumbnailSource={{ uri: path(['photoUrl64p'])(user) }}
-          imageSource={{ uri: path(['photoUrl480p'])(user) }}
+          thumbnailSource={{ uri: path(['photo', 'url64p'])(user) }}
+          imageSource={{ uri: path(['photo', 'url480p'])(user) }}
         />
       </TouchableOpacity>
 

--- a/src/components/Stories/index.js
+++ b/src/components/Stories/index.js
@@ -43,8 +43,8 @@ const Stories = ({
         <Avatar
           active
           size="medium"
-          thumbnailSource={{ uri: path(['photoUrl64p'])(authUser) }}
-          imageSource={{ uri: path(['photoUrl480p'])(authUser) }}
+          thumbnailSource={{ uri: path(['photo', 'url64p'])(authUser) }}
+          imageSource={{ uri: path(['photo', 'url480p'])(authUser) }}
           icon={true}
         />
         <Caption style={styling.username}>{path(['username'])(authUser)}</Caption>
@@ -59,8 +59,8 @@ const Stories = ({
           <Avatar
             active
             size="medium"
-            thumbnailSource={{ uri: path(['photoUrl64p'])(user) }}
-            imageSource={{ uri: path(['photoUrl480p'])(user) }}
+            thumbnailSource={{ uri: path(['photo', 'url64p'])(user) }}
+            imageSource={{ uri: path(['photo', 'url480p'])(user) }}
             themeCode={path(['themeCode'])(user)}
           />
           <Caption style={styling.username}>{path(['username'])(user)}</Caption>

--- a/src/components/Story/Header.js
+++ b/src/components/Story/Header.js
@@ -25,8 +25,8 @@ const Header = ({
     <View style={styling.root}>
       <View style={styling.action}>
         <Avatar
-          thumbnailSource={{ uri: path(['data', 'photoUrl64p'])(usersGetProfile) }}
-          imageSource={{ uri: path(['data', 'photoUrl64p'])(usersGetProfile) }}
+          thumbnailSource={{ uri: path(['data', 'photo', 'url64p'])(usersGetProfile) }}
+          imageSource={{ uri: path(['data', 'photo', 'url64p'])(usersGetProfile) }}
         />
 
         <View style={styling.text}>

--- a/src/components/Story/index.service.js
+++ b/src/components/Story/index.service.js
@@ -27,7 +27,6 @@ const StoryService = ({ children, }) => {
   const prevUserStoryPool = pathOr([], ['data', userStoryIndex - 1], usersGetFollowedUsersWithStories)
 
   const onSnapItem = (index) => {
-    console.log(index)
     navigation.setParams({
       user: usersGetFollowedUsersWithStories.data[index]
     })

--- a/src/components/Verification/index.js
+++ b/src/components/Verification/index.js
@@ -53,8 +53,8 @@ const Verification = ({
 
         <View style={styling.content}>
           <ModalProfileComponent
-            thumbnailSource={{ uri: path(['data', 'postedBy', 'photoUrl64p'])(postsSingleGet) }}
-            imageSource={{ uri: path(['data', 'postedBy', 'photoUrl480p'])(postsSingleGet) }}
+            thumbnailSource={{ uri: path(['data', 'postedBy', 'photo', 'url64p'])(postsSingleGet) }}
+            imageSource={{ uri: path(['data', 'postedBy', 'photo', 'url480p'])(postsSingleGet) }}
             title={path(['data', 'postedBy', 'username'])(postsSingleGet)}
             subtitle={`${t('Posted')} ${dayjs(path(['data', 'postedAt'])(postsSingleGet)).from(dayjs())}`}
           />

--- a/src/store/ducks/auth/selectors.js
+++ b/src/store/ducks/auth/selectors.js
@@ -15,11 +15,13 @@ export const authUserSelector = createSelector(
         privacyStatus: pathOr('', ['data', 'privacyStatus'], authUser),
         followCountsHidden: pathOr('', ['data', 'followCountsHidden'], authUser),
         viewCountsHidden: pathOr('', ['data', 'viewCountsHidden'], authUser),
-        photoUrl: pathOr('', ['data', 'photoUrl'], authUser),
-        photoUrl64p: pathOr('', ['data', 'photoUrl64p'], authUser),
-        photoUrl480p: pathOr('', ['data', 'photoUrl480p'], authUser),
-        photoUrl1080p: pathOr('', ['data', 'photoUrl1080p'], authUser),
-        photoUrl4k: pathOr('', ['data', 'photoUrl4k'], authUser),
+        photo: {
+          url: pathOr('', ['data', 'photo', 'url'], authUser),
+          url64p: pathOr('', ['data', 'photo', 'url64p'], authUser),
+          url480p: pathOr('', ['data', 'photo', 'url480p'], authUser),
+          url1080p: pathOr('', ['data', 'photo', 'url1080p'], authUser),
+          url4k: pathOr('', ['data', 'photo', 'url4k'], authUser),
+        },
       },
     },
   })

--- a/src/store/ducks/users/queries.js
+++ b/src/store/ducks/users/queries.js
@@ -56,37 +56,8 @@ export const user = `
   query user($userId: ID!) {
     user(userId: $userId) {
       ...userFragment
-      stories (limit: 10) {
-        items {
-          postId
-          postStatus
-          postType
-          postedAt
-          postedBy {
-            ...userFragment
-          }
-          expiresAt
-          text
-          textTaggedUsers {
-            tag
-            user {
-              ...userFragment
-            }
-          }
-          image {
-            ...imageFragment
-          }
-          isVerified
-          likeStatus
-          onymousLikeCount
-          anonymousLikeCount
-          viewedByCount
-        }
-        nextToken 
-      }
     }
   }
-  ${imageFragment}
   ${userFragment}
 `
 
@@ -120,37 +91,8 @@ export const setUserDetails = `
       verificationHidden: $verificationHidden
     ) {
       ...userFragment
-      stories (limit: 10) {
-        items {
-          postId
-          postStatus
-          postType
-          postedAt
-          postedBy {
-            ...userFragment
-          }
-          expiresAt
-          text
-          textTaggedUsers {
-            tag
-            user {
-              ...userFragment
-            }
-          }
-          image {
-            ...imageFragment
-          }
-          isVerified
-          likeStatus
-          onymousLikeCount
-          anonymousLikeCount
-          viewedByCount
-        }
-        nextToken 
-      }
     }
   }
-  ${imageFragment}
   ${userFragment}
 `
 
@@ -174,40 +116,11 @@ export const getFollowedUsersWithStories = `
       followedUsersWithStories(limit: $limit, nextToken: $nextToken) {
         items {
           ...userFragment
-          stories (limit: 10) {
-            items {
-              postId
-              postStatus
-              postType
-              postedAt
-              postedBy {
-                ...userFragment
-              }
-              expiresAt
-              text
-              textTaggedUsers {
-                tag
-                user {
-                  ...userFragment
-                }
-              }
-              image {
-                ...imageFragment
-              }
-              isVerified
-              likeStatus
-              onymousLikeCount
-              anonymousLikeCount
-              viewedByCount
-            }
-            nextToken 
-          }
         }
         nextToken
       }
     }
   }
-  ${imageFragment}
   ${userFragment}
 `
 
@@ -261,37 +174,8 @@ export const self = `
   query self {
     self {
       ...userFragment
-      stories (limit: 10) {
-        items {
-          postId
-          postStatus
-          postType
-          postedAt
-          postedBy {
-            ...userFragment
-          }
-          expiresAt
-          text
-          textTaggedUsers {
-            tag
-            user {
-              ...userFragment
-            }
-          }
-          image {
-            ...imageFragment
-          }
-          isVerified
-          likeStatus
-          onymousLikeCount
-          anonymousLikeCount
-          viewedByCount
-        }
-        nextToken 
-      }
     }
   }
-  ${imageFragment}
   ${userFragment}
 `
 

--- a/src/store/ducks/users/selectors.js
+++ b/src/store/ducks/users/selectors.js
@@ -15,11 +15,13 @@ export const usersGetProfileSelector = createSelector(
         privacyStatus: pathOr('', ['data', 'privacyStatus'], usersGetProfile),
         followCountsHidden: pathOr('', ['data', 'followCountsHidden'], usersGetProfile),
         viewCountsHidden: pathOr('', ['data', 'viewCountsHidden'], usersGetProfile),
-        photoUrl: pathOr('', ['data', 'photoUrl'], usersGetProfile),
-        photoUrl64p: pathOr('', ['data', 'photoUrl64p'], usersGetProfile),
-        photoUrl480p: pathOr('', ['data', 'photoUrl480p'], usersGetProfile),
-        photoUrl1080p: pathOr('', ['data', 'photoUrl1080p'], usersGetProfile),
-        photoUrl4k: pathOr('', ['data', 'photoUrl4k'], usersGetProfile),
+        photo: {
+          url: pathOr('', ['data', 'photo', 'url'], usersGetProfile),
+          url64p: pathOr('', ['data', 'photo', 'url64p'], usersGetProfile),
+          url480p: pathOr('', ['data', 'photo', 'url480p'], usersGetProfile),
+          url1080p: pathOr('', ['data', 'photo', 'url1080p'], usersGetProfile),
+          url4k: pathOr('', ['data', 'photo', 'url4k'], usersGetProfile),
+        },
       },
     },
   })

--- a/src/store/fragments.js
+++ b/src/store/fragments.js
@@ -16,7 +16,7 @@ export const imageFragment = `
 `
 
 export const userFragment = `
-  fragment userFragment on User {
+  fragment rootUser on User {
     userId
     username
     photo {
@@ -45,6 +45,40 @@ export const userFragment = `
     blockedStatus
     blockerStatus
   }
+
+  fragment userFragment on User {
+    ...rootUser
+
+    stories (limit: 12) {
+      items {
+        postId
+        postStatus
+        postType
+        postedAt
+        postedBy {
+          ...rootUser
+        }
+        expiresAt
+        text
+        textTaggedUsers {
+          tag
+          user {
+            ...rootUser
+          }
+        }
+        image {
+          ...imageFragment
+        }
+        isVerified
+        likeStatus
+        onymousLikeCount
+        anonymousLikeCount
+        viewedByCount
+      }
+      nextToken 
+    }
+  }
+
   ${imageFragment}
 `
 
@@ -67,7 +101,7 @@ export const commentFragment = `
 `
 
 export const postFragment = `
-  fragment postFragment on Post {
+  fragment rootPost on Post {
     postId
     postStatus
     postType
@@ -97,6 +131,10 @@ export const postFragment = `
     onymousLikeCount
     anonymousLikeCount
     viewedByCount
+  }
+
+  fragment postFragment on Post {
+    ...rootPost
     onymouslyLikedBy (limit: 1) {
       items {
         ...userFragment
@@ -105,19 +143,7 @@ export const postFragment = `
     }
     comments (limit: 3) {
       items {
-        commentId
-        commentedAt
-        commentedBy {
-          userId
-          username
-        }
-        text
-        textTaggedUsers {
-          tag
-          user {
-            userId
-          }
-        }
+        ...commentFragment
       }
     }
     album {
@@ -135,63 +161,13 @@ export const postFragment = `
       postsLastUpdatedAt
       posts(limit: 10) {
         items {
-          postId
-          postType
-          postedAt
-          postedBy {
-            ...userFragment
-          }
-          expiresAt
-          text
-          textTaggedUsers {
-            tag
-            user {
-              ...userFragment
-            }
-          }
-          image {
-            ...imageFragment
-          }
-          isVerified
-          likeStatus
-          commentCount
-          commentsDisabled
-          likesDisabled
-          sharingDisabled
-          verificationHidden
-          onymousLikeCount
-          anonymousLikeCount
-          viewedByCount
-          onymouslyLikedBy (limit: 1) {
-            items {
-              ...userFragment
-            }
-            nextToken
-          }
-          comments (limit: 3) {
-            items {
-              commentId
-              commentedAt
-              commentedBy {
-                userId
-                username
-              }
-              text
-              textTaggedUsers {
-                tag
-                user {
-                  userId
-                }
-              }
-            }
-          }
+          ...rootPost
         }
         nextToken
       }
     }
   }
-  ${imageFragment}
-  ${userFragment}
+  ${commentFragment}
 `
 
 export const albumFragment = `
@@ -203,18 +179,17 @@ export const albumFragment = `
     }
     name
     description
-    art {
-      imageFragment
-    }
     posts(limit: 10) {
       items {
         ...postFragment
       }
       nextToken
     }
+    art {
+      ...imageFragment
+    }
     postCount
     postsLastUpdatedAt
   }
-  ${imageFragment}
   ${postFragment}
 `

--- a/src/store/fragments.js
+++ b/src/store/fragments.js
@@ -1,12 +1,27 @@
+export const imageFragment = `
+  fragment imageFragment on Image {
+    url
+    url64p
+    url480p
+    url1080p
+    url4k
+    width
+    height
+    colors {
+      r
+      g
+      b
+    }
+  }
+`
+
 export const userFragment = `
   fragment userFragment on User {
     userId
     username
-    photoUrl
-    photoUrl64p
-    photoUrl480p
-    photoUrl1080p
-    photoUrl4k
+    photo {
+      ...imageFragment
+    }
     privacyStatus
     followedStatus
     followerStatus
@@ -30,23 +45,7 @@ export const userFragment = `
     blockedStatus
     blockerStatus
   }
-`
-
-export const imageFragment = `
-  fragment imageFragment on Image {
-    url
-    url64p
-    url480p
-    url1080p
-    url4k
-    width
-    height
-    colors {
-      r
-      g
-      b
-    }
-  }
+  ${imageFragment}
 `
 
 export const commentFragment = `

--- a/src/store/fragments.js
+++ b/src/store/fragments.js
@@ -128,11 +128,9 @@ export const postFragment = `
       }
       name
       description
-      url
-      url4k
-      url1080p
-      url480p
-      url64p
+      art {
+        ...imageFragment
+      }
       postCount
       postsLastUpdatedAt
       posts(limit: 10) {
@@ -192,8 +190,8 @@ export const postFragment = `
       }
     }
   }
-  ${userFragment}
   ${imageFragment}
+  ${userFragment}
 `
 
 export const albumFragment = `
@@ -205,11 +203,9 @@ export const albumFragment = `
     }
     name
     description
-    url
-    url4k
-    url1080p
-    url480p
-    url64p
+    art {
+      imageFragment
+    }
     posts(limit: 10) {
       items {
         ...postFragment
@@ -219,5 +215,6 @@ export const albumFragment = `
     postCount
     postsLastUpdatedAt
   }
+  ${imageFragment}
   ${postFragment}
 `

--- a/src/templates/ReactionsPreview/index.js
+++ b/src/templates/ReactionsPreview/index.js
@@ -33,8 +33,8 @@ const ReactionsPreviewTemplate = ({
           <View style={styling.profile}>
             <Avatar
               size="micro"
-              thumbnailSource={{ uri: path(['onymouslyLikedBy', 'items', '0', 'photoUrl64p'])(post) }}
-              imageSource={{ uri: path(['onymouslyLikedBy', 'items', '0', 'photoUrl64p'])(post) }}
+              thumbnailSource={{ uri: path(['onymouslyLikedBy', 'items', '0', 'photo', 'url64p'])(post) }}
+              imageSource={{ uri: path(['onymouslyLikedBy', 'items', '0', 'photo', 'url64p'])(post) }}
             />
           </View>
         : null}


### PR DESCRIPTION
Also introduced in the backend in `v2020-02-26.1`: `User.photo` and `Album.art`. The idea is to re-use the `type Image` here, which allows the frontend to re-use the fragment `imageFragment` and also allows similar re-use on the backend as well.

So what was previously:

```gql
type User {
  photoUrl: AWSURL
  photoUrl64p: AWSURL
  photoUrl480p: AWSURL
  photoUrl1080p: AWSURL
  photoUrl4k: AWSURL
  ...
}

type Album {
  url: AWSURL
  url4k: AWSURL
  url1080p: AWSURL
  url480p: AWSURL
  url64p: AWSURL
  ...
}
```

Will become:

```gql
type Image {
  url: AWSURL!
  url64p: AWSURL!
  url480p: AWSURL!
  url1080p: AWSURL!
  url4k: AWSURL!
  ...
}

type User {
  photo: Image
  ...
}

type Album {
  art: Image
  ...
}
```

Right now, both the old and new ways of access the urls are supported on the backend. Once the frontend moves over to accessing these urls the new way, then on the backend I will drop support for the old way.

