### PR TITLE
Retain source image metadata when reading HEIC files from gallery

### DIFF
--- a/patches/react-native-fs+2.16.6.patch
+++ b/patches/react-native-fs+2.16.6.patch
@@ -120,23 +120,35 @@ index c443d20..e52ad1e 100755
 +
 +        } else if (result) {
 +
++            // extract source image metadata
++            CGDataProviderRef dataProvider = CGImageGetDataProvider(result.CGImage);
++            CGImageSourceRef src = CGImageSourceCreateWithData(dataProvider.data, NULL);
++            CFDictionaryRef metadata = CGImageSourceCopyProperties(src, NULL)
++
++            // set compression quality to lossless
++            CFMutableDictionaryRef options = CFDictionaryCreateMutableCopy(NULL, 0, metadata);
++            CFDictionaryAddValue(options, @kCGImageDestinationLossyCompressionQuality, @1);
++
 +            NSData *imageData = nil;
 +            NSMutableData *destinationData = [NSMutableData new];
 +            CGImageDestinationRef destination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)destinationData, (__bridge CFStringRef)AVFileTypeHEIC, 1, NULL);
-+            NSDictionary *options = @{(__bridge NSString *)kCGImageDestinationLossyCompressionQuality: @1};
 +            
 +            // iOS devices seem to corrupt image data when concurrently creating HEIC images.
 +            // Locking to ensure HEIC creation doesn't occur concurrently.
 +            pthread_mutex_t *lock = tj_HEICEncodingLock();
 +            pthread_mutex_lock(lock);
 +            
-+            CGImageDestinationAddImage(destination, result.CGImage, (__bridge CFDictionaryRef)options);
++            CGImageDestinationAddImage(destination, result.CGImage, options);
 +            CGImageDestinationFinalize(destination);
 +            imageData = destinationData;
 +
 +            [imageData writeToFile:imageDestination atomically:YES];
 +            resolve(imageDestination);
 +            CFRelease(destination);
++            CFRelease(dataProvider);
++            CFRelease(src);
++            CFRelease(metadata);
++            CFRelease(options);
  
          } else {
              NSMutableDictionary* details = [NSMutableDictionary dictionary];


### PR DESCRIPTION
This is more of a skeleton than anything. This probably doesn't even compile... I have not fired up xcode to try. I apologize in advance for submitting a PR that doesn't even compile.

The problem this PR tries to fix is that the HEIC images that the backend is receiving from the frontend have all their original metadata stripped off. We need that metadata to help with post verification.

To do this, I think we need to use [CGImageSourceCopyProperties](https://developer.apple.com/documentation/imageio/1465443-cgimagesourcecopyproperties?language=objc) to get a copy of the source image metadata, and then pass that in to the call to [CGImageDestinationAddImage](https://developer.apple.com/documentation/imageio/1464962-cgimagedestinationaddimage?language=objc).

(Note: github is coloring the line-by-line changes in this PR wrong because it's an edit to a patch... some of the lines are rendered green, even though this PR does not actually change or add them.)