### PR TITLE
Remove GQL for Subscription.onPostNotification

### DIFF
--- a/src/store/ducks/posts/queries.js
+++ b/src/store/ducks/posts/queries.js
@@ -332,15 +332,3 @@ export const comments = `
   }
   ${commentFragment}
 `
-
-export const onPostNotification = `
-  subscription onPostNotification ($userId: ID!) {
-    onPostNotification (userId: $userId) {
-      userId
-      type
-      post {
-        postId
-      }
-    }
-  }
-`


### PR DESCRIPTION
This stanza of GQL appears to be dead code, so I don't think this PR actually changes any functionality. But before I remove support from this from the backend, I figure best to 100% remove it from the frontend.

t looks like the frontend has already migrated over to using the `POST_COMPLETED` notification instead of this notification - awesome, nice work.