### PR TITLE
Remove unused user-initialization GQL mutations

### DIFF
--- a/src/store/ducks/auth/saga/authSigninApple.js
+++ b/src/store/ducks/auth/saga/authSigninApple.js
@@ -8,7 +8,6 @@ import { handleAnonymousSignin } from 'store/ducks/auth/saga/authSigninAnonymous
 import * as navigationActions from 'navigation/actions'
 import * as NavigationService from 'services/Navigation'
 import authorize from 'store/ducks/auth/saga/authorize'
-import * as signupQueries from 'store/ducks/signup/queries'
 
 function* getApplePayload() {
   const apple = yield call(federatedAppleSignin)
@@ -23,14 +22,6 @@ function* getApplePayload() {
   }
 
   return userPayload
-}
-
-function* createAppleUser(userPayload) {
-  yield call([queryService, 'apiRequest'], signupQueries.createAppleUser, {
-    username: userPayload.email.split('@')[0],
-    fullName: userPayload.name,
-    appleIdToken: userPayload.token,
-  })
 }
 
 /**
@@ -54,13 +45,7 @@ function* appleSignInFlow(userPayload) {
   }
 
   yield call([AwsAuth, 'federatedSignIn'], 'appleid.apple.com', credentials, userPayload)
-
-  try {
-    yield call(authorize)
-  } catch (error) {
-    yield call(createAppleUser, userPayload)
-    yield call(authorize)
-  }
+  yield call(authorize)
 }
 
 function* handleAuthAppleRequest() {

--- a/src/store/ducks/auth/saga/authSigninGoogle.js
+++ b/src/store/ducks/auth/saga/authSigninGoogle.js
@@ -8,7 +8,6 @@ import { handleAnonymousSignin } from 'store/ducks/auth/saga/authSigninAnonymous
 import * as navigationActions from 'navigation/actions'
 import * as NavigationService from 'services/Navigation'
 import authorize from 'store/ducks/auth/saga/authorize'
-import * as signupQueries from 'store/ducks/signup/queries'
 
 /**
  * Authenticate using google into identity pool
@@ -26,14 +25,6 @@ function* getGooglePayload() {
   }
 
   return userPayload
-}
-
-function* createGoogleUser(userPayload) {
-  yield call([queryService, 'apiRequest'], signupQueries.createGoogleUser, {
-    username: userPayload.email.split('@')[0],
-    fullName: userPayload.name,
-    googleIdToken: userPayload.token,
-  })
 }
 
 function* googleSignUpFlow(userPayload) {
@@ -54,13 +45,7 @@ function* googleSignInFlow(userPayload) {
   }
 
   yield call([AwsAuth, 'federatedSignIn'], 'google', credentials, userPayload)
-
-  try {
-    yield call(authorize)
-  } catch (error) {
-    yield call(createGoogleUser, userPayload)
-    yield call(authorize)
-  }
+  yield call(authorize)
 }
 
 /**

--- a/src/store/ducks/signup/queries.js
+++ b/src/store/ducks/signup/queries.js
@@ -2,15 +2,6 @@ import {
   userFragment,
 } from 'store/fragments'
 
-export const createCognitoOnlyUser = `
-  mutation createCognitoOnlyUser($username: String!, $fullName: String) {
-    createCognitoOnlyUser(username: $username, fullName: $fullName) {
-      ...userFragment
-    }
-  }
-  ${userFragment}
-`
-
 export const createGoogleUser = `
   mutation createGoogleUser($username: String!, $fullName: String, $googleIdToken: String!) {
     createGoogleUser(username: $username, fullName: $fullName, googleIdToken: $googleIdToken) {

--- a/src/store/ducks/signup/queries.js
+++ b/src/store/ducks/signup/queries.js
@@ -2,15 +2,6 @@ import {
   userFragment,
 } from 'store/fragments'
 
-export const createAppleUser = `
-  mutation createAppleUser($username: String!, $fullName: String, $appleIdToken: String!) {
-    createAppleUser(username: $username, fullName: $fullName, appleIdToken: $appleIdToken) {
-      ...userFragment
-    }
-  }
-  ${userFragment}
-`
-
 export const setUserAcceptedEULAVersion = `
   mutation SetUserAcceptedEULAVersion($version: String!) {
     setUserAcceptedEULAVersion(version: $version) {

--- a/src/store/ducks/signup/queries.js
+++ b/src/store/ducks/signup/queries.js
@@ -2,15 +2,6 @@ import {
   userFragment,
 } from 'store/fragments'
 
-export const createGoogleUser = `
-  mutation createGoogleUser($username: String!, $fullName: String, $googleIdToken: String!) {
-    createGoogleUser(username: $username, fullName: $fullName, googleIdToken: $googleIdToken) {
-      ...userFragment
-    }
-  }
-  ${userFragment}
-`
-
 export const createAppleUser = `
   mutation createAppleUser($username: String!, $fullName: String, $appleIdToken: String!) {
     createAppleUser(username: $username, fullName: $fullName, appleIdToken: $appleIdToken) {


### PR DESCRIPTION
On the backend, we're currently supporting two flows for initializing a new user.

- create a new user from nothing using `Mutation.createCognitoOnlyUser` / `Mutation.createGoogleUser` / `Mutation.createAppleUser` / `Mutation.createFacebookUser`

OR

- first create an anonymous user: `Mutation.createAnonymousUser`
- then upgrade them using `Mutation.linkAppleLogin` / `Mutation.linkFacebookLogin` / `Mutation.linkGoogleLogin` / `Mutation.setUserPassword`

It appears the frontend is now only using the 2nd of these two flows. This PR removes references to the first flow.