### PR TITLE
Remove unused Mutation.linkFacebookLogin

### DIFF
--- a/src/store/ducks/auth/queries.js
+++ b/src/store/ducks/auth/queries.js
@@ -21,15 +21,6 @@ export const linkAppleLogin = `
   ${usersSingle.singleUserFragment}
 `
 
-export const linkFacebookLogin = `
-  mutation linkFacebookLogin($facebookAccessToken: String!) {
-    linkFacebookLogin(facebookAccessToken: $facebookAccessToken) {
-      ...singleUserFragment
-    }
-  }
-  ${usersSingle.singleUserFragment}
-`
-
 export const linkGoogleLogin = `
   mutation linkGoogleLogin($googleIdToken: String!) {
     linkGoogleLogin(googleIdToken: $googleIdToken) {


### PR DESCRIPTION
Over in the backend repo, rather than spend time to fix all the Facebook-authentication stuff to do the right thing, we are removing it.

https://real-social.atlassian.net/browse/BE-179

This mutation appears to be completely unused, so I think it's safe to remove.