### PR TITLE
Google expiry timestamp format 

### DIFF
--- a/src/services/Google.js
+++ b/src/services/Google.js
@@ -45,7 +45,7 @@ export const signin = async () => {
 
   return {
     token: userInfo.idToken,
-    expires_at: parseInt(tokeninfo.exp, 10),
+    expires_at: parseInt(tokeninfo.exp, 10) * 1000,
     user: userInfo.user,
   }
 }
@@ -57,7 +57,7 @@ export const refresh = async () => {
 
   return {
     token: userInfo.idToken,
-    expires_at: parseInt(tokeninfo.exp, 10),
+    expires_at: parseInt(tokeninfo.exp, 10) * 1000,
     user: userInfo.user,
   }
 }


### PR DESCRIPTION
Fix google token refresh expiry date to match timestamp format of aws-amplify. 

Amplify has following mechanism for checking timestamp format:
https://github.com/aws-amplify/amplify-js/blob/40cc22f8b332e4748c85504ca8e2ac2713fd87d1/packages/core/src/Credentials.ts#L149-L152

```js
expires_at =
  new Date(expires_at).getFullYear() === 1970
    ? expires_at * 1000
    : expires_at;
```